### PR TITLE
adding "list" permission for "nodes"

### DIFF
--- a/operator/base/clusterrole.yaml
+++ b/operator/base/clusterrole.yaml
@@ -47,8 +47,10 @@ rules:
       - ""
     resources:
       - pods
+      - nodes
     verbs:
       - get
+      - list
   - apiGroups:
       - apps
     resources:


### PR DESCRIPTION
Checking for node taints needs "list" permission for the clusterrole. 